### PR TITLE
Fix sitemap team support URL closure

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -174,6 +174,7 @@
         <priority>0.5</priority>
         <xhtml:link rel="alternate" hreflang="zh-CN" href="https://bl4builds.net/builds/team-support.html" />
         <xhtml:link rel="alternate" hreflang="en" href="https://bl4builds.net/en/builds/team-support.html" />
+    </url>
 
     <!-- Tag landing pages (zh/en pairs) -->
     <url>


### PR DESCRIPTION
## Summary
- close the `<url>` element for the English team support build entry in the sitemap

## Testing
- python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('sitemap.xml')
print('OK')
PY

------
https://chatgpt.com/codex/tasks/task_e_68cec881c130832eb8a366f3d8dafa05